### PR TITLE
Update and select detail exercise event

### DIFF
--- a/fitConnect/src/main/java/com/example/fitconnect/config/error/ErrorMessages.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/config/error/ErrorMessages.java
@@ -20,7 +20,9 @@ public enum ErrorMessages {
     REGISTRATION_DATE_INVALID("시작 시간은 종료시간보다 빨라야 합니다"),
     PARTICIPANTS_NUMBER_INVALID("모집 인워은 최소 1명에서 100명 사이 입니다."),
     TIME_NULL("시작시간 혹은 종료시간이 NULL 입니다."),
-    USER_NOT_FOUND("회원은 찾을 수 없습니다.");
+    USER_NOT_FOUND("회원은 찾을 수 없습니다."),
+    EVENT_NOT_FOUND("글을 찾을 수 없습니다."),
+    UNAUTHORIZED_USER("수정 권한이 없습니다.");
 
 
 

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
@@ -4,13 +4,17 @@ import com.example.fitconnect.config.service.CommonService;
 import com.example.fitconnect.domain.event.domain.Category;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.event.dto.ExerciseEventRegistrationDto;
+import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.service.event.ExerciseEventFindService;
 import com.example.fitconnect.service.event.ExerciseEventRegistrationService;
+import com.example.fitconnect.service.event.ExerciseEventUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,6 +30,8 @@ public class ExerciseEventController {
     private final ExerciseEventRegistrationService registrationService;
 
     private final ExerciseEventFindService exerciseEventFindService;
+
+    private final ExerciseEventUpdateService updateService;
     private final CommonService commonService;
 
     @PostMapping("/register")
@@ -44,5 +50,15 @@ public class ExerciseEventController {
             @RequestParam(required = false) String description) {
         Page<ExerciseEvent> events = exerciseEventFindService.findEvents(category, description, page);
         return ResponseEntity.ok(events);
+    }
+
+    @PutMapping("/{eventId}")
+    public ResponseEntity<ExerciseEvent> updateEvent(
+            @PathVariable Long eventId,
+            @RequestBody ExerciseEventUpdateDto updateDto,
+            HttpSession session) {
+        Long userId = commonService.extractUserIdFromSession(session);
+        ExerciseEvent updatedEvent = updateService.updateEvent(eventId, updateDto, userId);
+        return ResponseEntity.ok(updatedEvent);
     }
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
@@ -5,12 +5,14 @@ import com.example.fitconnect.domain.event.domain.Category;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.event.dto.ExerciseEventRegistrationDto;
 import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
+import com.example.fitconnect.service.event.ExerciseEventDeleteService;
 import com.example.fitconnect.service.event.ExerciseEventFindService;
 import com.example.fitconnect.service.event.ExerciseEventRegistrationService;
 import com.example.fitconnect.service.event.ExerciseEventUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,10 +30,10 @@ import jakarta.servlet.http.HttpSession;
 public class ExerciseEventController {
 
     private final ExerciseEventRegistrationService registrationService;
-
     private final ExerciseEventFindService exerciseEventFindService;
-
     private final ExerciseEventUpdateService updateService;
+
+    private final ExerciseEventDeleteService exerciseEventDeleteService;
     private final CommonService commonService;
 
     @PostMapping("/register")
@@ -48,7 +50,8 @@ public class ExerciseEventController {
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Category category,
             @RequestParam(required = false) String description) {
-        Page<ExerciseEvent> events = exerciseEventFindService.findEvents(category, description, page);
+        Page<ExerciseEvent> events = exerciseEventFindService.findEvents(category, description,
+                page);
         return ResponseEntity.ok(events);
     }
 
@@ -61,4 +64,12 @@ public class ExerciseEventController {
         ExerciseEvent updatedEvent = updateService.updateEvent(eventId, updateDto, userId);
         return ResponseEntity.ok(updatedEvent);
     }
+
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<?> deleteEvent(@PathVariable Long eventId, HttpSession session) {
+        Long userId = commonService.extractUserIdFromSession(session);
+        exerciseEventDeleteService.deleteEvent(eventId, userId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/event/domain/ExerciseEvent.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/event/domain/ExerciseEvent.java
@@ -1,5 +1,8 @@
 package com.example.fitconnect.domain.event.domain;
 
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.BusinessException;
+import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.domain.global.BaseEntity;
 import com.example.fitconnect.domain.registration.Registration;
 import com.example.fitconnect.domain.user.domain.User;
@@ -62,6 +65,15 @@ public class ExerciseEvent extends BaseEntity {
         this.registrationPolicy = registrationPolicy;
         this.location = location;
         this.category = category;
+    }
+    public void update(ExerciseEventUpdateDto updateDto, Long userId) {
+        if (!this.organizer.getId().equals(userId)) {
+            throw new BusinessException(ErrorMessages.UNAUTHORIZED_USER);
+        }
+        this.eventDetail = updateDto.getEventDetail().toEntity();
+        this.registrationPolicy = updateDto.getRecruitmentPolicy().toEntity();
+        this.location = updateDto.getLocation().toEntity();
+        this.category = updateDto.getCategory();
     }
 
     public ExerciseEvent() {

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/event/dto/ExerciseEventUpdateDto.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/event/dto/ExerciseEventUpdateDto.java
@@ -1,0 +1,24 @@
+package com.example.fitconnect.domain.event.dto;
+
+import com.example.fitconnect.domain.event.domain.Category;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ExerciseEventUpdateDto {
+    private EventDetailDto eventDetail;
+    private RecruitmentPolicyDto recruitmentPolicy;
+    private LocationDto location;
+    private Category category;
+
+    public ExerciseEventUpdateDto(EventDetailDto eventDetail,
+            RecruitmentPolicyDto recruitmentPolicy,
+            LocationDto location, Category category) {
+        this.eventDetail = eventDetail;
+        this.recruitmentPolicy = recruitmentPolicy;
+        this.location = location;
+        this.category = category;
+    }
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventDeleteService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventDeleteService.java
@@ -1,0 +1,27 @@
+package com.example.fitconnect.service.event;
+
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.BusinessException;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExerciseEventDeleteService {
+
+    private final ExerciseEventRepository exerciseEventRepository;
+
+    public void deleteEvent(Long eventId, Long userId) {
+        ExerciseEvent event = exerciseEventRepository.findById(eventId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.EVENT_NOT_FOUND));
+
+        if (!event.getOrganizer().getId().equals(userId)) {
+            throw new BusinessException(ErrorMessages.UNAUTHORIZED_USER);
+        }
+
+        exerciseEventRepository.delete(event);
+    }
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventUpdateService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventUpdateService.java
@@ -1,0 +1,25 @@
+package com.example.fitconnect.service.event;
+
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExerciseEventUpdateService {
+
+    private final ExerciseEventRepository exerciseEventRepository;
+
+    public ExerciseEvent updateEvent(Long eventId, ExerciseEventUpdateDto updateDto,Long userId) {
+        ExerciseEvent event = exerciseEventRepository.findById(eventId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.EVENT_NOT_FOUND));
+
+        event.update(updateDto, userId);
+
+        return event;
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/controller/event/ExerciseEventControllerTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/controller/event/ExerciseEventControllerTest.java
@@ -11,6 +11,7 @@ import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.domain.event.dto.LocationDto;
 import com.example.fitconnect.domain.event.dto.RecruitmentPolicyDto;
 import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.service.event.ExerciseEventDeleteService;
 import com.example.fitconnect.service.event.ExerciseEventFindService;
 import com.example.fitconnect.service.event.ExerciseEventRegistrationService;
 import com.example.fitconnect.service.event.ExerciseEventUpdateService;
@@ -36,6 +37,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -58,6 +60,9 @@ public class ExerciseEventControllerTest {
     @MockBean
     private ExerciseEventUpdateService exerciseEventUpdateService;
 
+    @MockBean
+    private ExerciseEventDeleteService exerciseEventDeleteService;
+
     private final Long userId = 1L;
     private final Long eventId = 1L;
 
@@ -65,7 +70,7 @@ public class ExerciseEventControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(
                 new ExerciseEventController(registrationService, exerciseEventFindService,
-                        exerciseEventUpdateService, commonService)).build();
+                        exerciseEventUpdateService,exerciseEventDeleteService, commonService)).build();
         given(commonService.extractUserIdFromSession(any())).willReturn(userId);
     }
 
@@ -96,6 +101,15 @@ public class ExerciseEventControllerTest {
         performPut("/api/events/" + eventId, updateDto)
                 .andExpect(status().isOk());
     }
+    @Test
+    public void deleteEventShouldReturnStatusOk() throws Exception {
+        Long eventId = 1L;
+        setupDeleteService(eventId);
+
+        performDelete("/api/events/" + eventId)
+                .andExpect(status().isOk());
+    }
+
 
     private void setupRegistrationService(ExerciseEventRegistrationDto dto) {
         given(registrationService.registerEvent(eq(userId), eq(dto)))
@@ -115,6 +129,10 @@ public class ExerciseEventControllerTest {
                 .willReturn(new ExerciseEvent());
     }
 
+    private void setupDeleteService(Long eventId) {
+        doNothing().when(exerciseEventDeleteService).deleteEvent(eq(eventId), eq(userId));
+    }
+
     private ResultActions performPost(String url, Object dto) throws Exception {
         return mockMvc.perform(MockMvcRequestBuilders.post(url)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -132,6 +150,10 @@ public class ExerciseEventControllerTest {
         return mockMvc.perform(put(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(asJsonString(dto)));
+    }
+
+    private ResultActions performDelete(String url) throws Exception {
+        return mockMvc.perform(MockMvcRequestBuilders.delete(url));
     }
 
     private String asJsonString(final Object obj) {

--- a/fitConnect/src/test/java/com/example/fitconnect/controller/event/ExerciseEventControllerTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/controller/event/ExerciseEventControllerTest.java
@@ -7,11 +7,13 @@ import com.example.fitconnect.domain.event.domain.City;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.event.dto.EventDetailDto;
 import com.example.fitconnect.domain.event.dto.ExerciseEventRegistrationDto;
+import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.domain.event.dto.LocationDto;
 import com.example.fitconnect.domain.event.dto.RecruitmentPolicyDto;
 import com.example.fitconnect.domain.user.domain.User;
 import com.example.fitconnect.service.event.ExerciseEventFindService;
 import com.example.fitconnect.service.event.ExerciseEventRegistrationService;
+import com.example.fitconnect.service.event.ExerciseEventUpdateService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.LocalDateTime;
@@ -26,13 +28,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -46,55 +51,87 @@ public class ExerciseEventControllerTest {
     private JwtService jwtService;
     @MockBean
     private ExerciseEventRegistrationService registrationService;
-
     @MockBean
     private CommonService commonService;
-
     @MockBean
     private ExerciseEventFindService exerciseEventFindService;
+    @MockBean
+    private ExerciseEventUpdateService exerciseEventUpdateService;
+
+    private final Long userId = 1L;
+    private final Long eventId = 1L;
 
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(
                 new ExerciseEventController(registrationService, exerciseEventFindService,
-                        commonService)).build();
+                        exerciseEventUpdateService, commonService)).build();
+        given(commonService.extractUserIdFromSession(any())).willReturn(userId);
     }
 
     @Test
-    public void registerEvent_Success() throws Exception {
-        Long userId = 1L;
+    public void registerEventShouldReturnStatusOk() throws Exception {
         ExerciseEventRegistrationDto registrationDto = createEventRegistrationDto();
+        setupRegistrationService(registrationDto);
 
-        given(commonService.extractUserIdFromSession(any())).willReturn(userId);
-        given(registrationService.registerEvent(eq(userId), eq(registrationDto)))
-                .willReturn(registrationDto.toEntity(new User()));
-
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/events/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(asJsonString(registrationDto)))
+        performPost("/api/events/register", registrationDto)
                 .andExpect(status().isOk());
     }
 
     @Test
-    public void findEvent_Success() throws Exception {
-        int page = 0;
-        Category category = Category.SOCCER;
-        String description = "Soccer match";
-        ExerciseEvent event = createEventRegistrationDto().toEntity(new User());
+    public void findEventShouldReturnStatusOk() throws Exception {
+        setupFindService();
 
-        Page<ExerciseEvent> expectedPage = new PageImpl<>(Collections.singletonList(event),
-                PageRequest.of(page, 10), 1);
-
-        given(exerciseEventFindService.findEvents(category, description, page))
-                .willReturn(expectedPage);
-
-        mockMvc.perform(get("/api/events")
-                        .param("page", "0")
-                        .param("category", "SOCCER")
-                        .param("description", "Soccer match"))
+        performGet("/api/events", "0", "SOCCER", "Soccer match")
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").exists())
                 .andExpect(jsonPath("$.content[0].category").value("SOCCER"));
+    }
+
+    @Test
+    public void updateEventShouldReturnStatusOk() throws Exception {
+        ExerciseEventUpdateDto updateDto = createUpdateDto();
+        setupUpdateService(updateDto);
+
+        performPut("/api/events/" + eventId, updateDto)
+                .andExpect(status().isOk());
+    }
+
+    private void setupRegistrationService(ExerciseEventRegistrationDto dto) {
+        given(registrationService.registerEvent(eq(userId), eq(dto)))
+                .willReturn(dto.toEntity(new User()));
+    }
+
+    private void setupFindService() {
+        ExerciseEvent event = createEventRegistrationDto().toEntity(new User());
+        Page<ExerciseEvent> expectedPage = new PageImpl<>(Collections.singletonList(event),
+                PageRequest.of(0, 10), 1);
+        given(exerciseEventFindService.findEvents(any(), any(), anyInt()))
+                .willReturn(expectedPage);
+    }
+
+    private void setupUpdateService(ExerciseEventUpdateDto dto) {
+        given(exerciseEventUpdateService.updateEvent(eq(eventId), eq(dto), eq(userId)))
+                .willReturn(new ExerciseEvent());
+    }
+
+    private ResultActions performPost(String url, Object dto) throws Exception {
+        return mockMvc.perform(MockMvcRequestBuilders.post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(dto)));
+    }
+
+    private ResultActions performGet(String url, String page, String category, String description) throws Exception {
+        return mockMvc.perform(get(url)
+                .param("page", page)
+                .param("category", category)
+                .param("description", description));
+    }
+
+    private ResultActions performPut(String url, Object dto) throws Exception {
+        return mockMvc.perform(put(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(dto)));
     }
 
     private String asJsonString(final Object obj) {
@@ -117,5 +154,14 @@ public class ExerciseEventControllerTest {
 
         return new ExerciseEventRegistrationDto(eventDetailDto,
                 recruitmentPolicyDto, locationDto, category);
+    }
+
+    private ExerciseEventUpdateDto createUpdateDto() {
+        return new ExerciseEventUpdateDto(
+                new EventDetailDto("Updated Description", LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(1).plusHours(2)),
+                new RecruitmentPolicyDto(50, LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2)),
+                new LocationDto(City.SEOUL, "서울시 송파구"),
+                Category.BASKETBALL
+        );
     }
 }

--- a/fitConnect/src/test/java/com/example/fitconnect/service/event/ExerciseEventDeleteServiceTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/service/event/ExerciseEventDeleteServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.fitconnect.service.event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.example.fitconnect.config.exception.BusinessException;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.domain.user.domain.Role;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.domain.user.domain.UserBaseInfo;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ExerciseEventDeleteServiceTest {
+
+    @Mock
+    private ExerciseEventRepository exerciseEventRepository;
+
+    @InjectMocks
+    private ExerciseEventDeleteService exerciseEventDeleteService;
+
+    private User user;
+    private ExerciseEvent event;
+    private Long eventId = 1L;
+    private Long userId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(new UserBaseInfo("user@example.com", "nickname", "url"), Role.MEMBER);
+        user.setId(userId);
+        event = new ExerciseEvent();
+        event.setOrganizer(user);
+    }
+
+    @Test
+    void deleteEvent_Success() {
+        given(exerciseEventRepository.findById(eventId)).willReturn(Optional.of(event));
+
+        exerciseEventDeleteService.deleteEvent(eventId, userId);
+
+    }
+
+    @Test
+    void deleteEvent_NotFoundEntity() {
+        given(exerciseEventRepository.findById(eventId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> exerciseEventDeleteService.deleteEvent(eventId, userId))
+                .isInstanceOf(EntityNotFoundException.class);
+
+    }
+
+    @Test
+    void deleteEvent_InvalidUser() {
+        Long anotherUserId = 2L;
+        given(exerciseEventRepository.findById(eventId)).willReturn(Optional.of(event));
+
+        assertThatThrownBy(() -> exerciseEventDeleteService.deleteEvent(eventId, anotherUserId))
+                .isInstanceOf(BusinessException.class);
+
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/service/event/ExerciseEventUpdateServiceTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/service/event/ExerciseEventUpdateServiceTest.java
@@ -1,0 +1,84 @@
+package com.example.fitconnect.service.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.*;
+import com.example.fitconnect.domain.event.dto.*;
+import com.example.fitconnect.domain.user.domain.Role;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.domain.user.domain.UserBaseInfo;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+
+import com.example.fitconnect.service.event.ExerciseEventUpdateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+class ExerciseEventUpdateServiceTest {
+
+    @Mock
+    private ExerciseEventRepository repository;
+
+    @InjectMocks
+    private ExerciseEventUpdateService service;
+
+    private User user;
+    private ExerciseEvent existingEvent;
+    private ExerciseEventUpdateDto updateDto;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(new UserBaseInfo("test123@naver.com", "hi", ".com"), Role.MEMBER);
+        user.setId(1L);
+        existingEvent = createEvent();
+        updateDto = createUpdateDto();
+    }
+
+    @Test
+    void updateValidEvent() {
+        given(repository.findById(1L)).willReturn(Optional.of(existingEvent));
+
+        ExerciseEvent updatedEvent = service.updateEvent(1L, updateDto, 1L);
+
+        assertThat(updatedEvent).isNotNull();
+        assertThat(updatedEvent.getEventDetail().getDescription())
+                .isEqualTo(updateDto.getEventDetail().getDescription());
+        assertThat(updatedEvent.getCategory()).isEqualTo(updateDto.getCategory());
+    }
+
+    @Test
+    void updateInvalidEvent() {
+        given(repository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateEvent(1L, updateDto, 1L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    private ExerciseEvent createEvent() {
+        return new ExerciseEventRegistrationDto(
+                new EventDetailDto("Description", LocalDateTime.now(), LocalDateTime.now().plusHours(2)),
+                new RecruitmentPolicyDto(30, LocalDateTime.now(), LocalDateTime.now().plusDays(1)),
+                new LocationDto(City.SEOUL, "서울시 강남구"),
+                Category.SOCCER
+        ).toEntity(user);
+    }
+
+    private ExerciseEventUpdateDto createUpdateDto() {
+        return new ExerciseEventUpdateDto(
+                new EventDetailDto("Updated Description", LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(1).plusHours(2)),
+                new RecruitmentPolicyDto(50, LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2)),
+                new LocationDto(City.SEOUL, "서울시 송파구"),
+                Category.BASKETBALL
+        );
+    }
+}


### PR DESCRIPTION
## 1. Changes

- 운동 이벤트 자세히 보기 기능 추가. 
- 운동 이벤트 업데이트, 삭제 기능 추가
- 운동 이벤트 업데이트 Dto 추가 



## 3. Issues

1 업데이트와 등록을 받는 Dto 가 같아서 코드의 중복을 제거하고 사용해야 될지 각각의 객체를 사용할지 아님 BaseDto 를 생성해서 상속받아 만들지 고민했는데 확장과 유지보수를 위해 각각을 분리해서 사용했습니다. 그렇게 했을때 처음 제 코드를 보는 사람도 이해하기 쉬울꺼 같습니다.
2. 

## 4. To Reviewer

-

## 5. Plans
- [ ] - 이벤트 신청,취소
- [ ] - 이벤트 신청 승인 취소  
