### PR TITLE
Create registration service

### DIFF
--- a/fitConnect/src/main/java/com/example/fitconnect/config/error/ErrorMessages.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/config/error/ErrorMessages.java
@@ -22,6 +22,8 @@ public enum ErrorMessages {
     TIME_NULL("시작시간 혹은 종료시간이 NULL 입니다."),
     USER_NOT_FOUND("회원은 찾을 수 없습니다."),
     EVENT_NOT_FOUND("글을 찾을 수 없습니다."),
+
+    REGISTRATION_NOT_FOUND("신청현황을 찾을 수 없습니다."),
     UNAUTHORIZED_USER("수정 권한이 없습니다.");
 
 

--- a/fitConnect/src/main/java/com/example/fitconnect/config/error/ErrorMessages.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/config/error/ErrorMessages.java
@@ -20,7 +20,9 @@ public enum ErrorMessages {
     REGISTRATION_DATE_INVALID("시작 시간은 종료시간보다 빨라야 합니다"),
     PARTICIPANTS_NUMBER_INVALID("모집 인워은 최소 1명에서 100명 사이 입니다."),
     TIME_NULL("시작시간 혹은 종료시간이 NULL 입니다."),
-    USER_NOT_FOUND("회원은 찾을 수 없습니다.");
+    USER_NOT_FOUND("회원은 찾을 수 없습니다."),
+    EVENT_NOT_FOUND("글을 찾을 수 없습니다."),
+    UNAUTHORIZED_USER("수정 권한이 없습니다.");
 
 
 

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
@@ -4,13 +4,17 @@ import com.example.fitconnect.config.service.CommonService;
 import com.example.fitconnect.domain.event.domain.Category;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.event.dto.ExerciseEventRegistrationDto;
+import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.service.event.ExerciseEventFindService;
 import com.example.fitconnect.service.event.ExerciseEventRegistrationService;
+import com.example.fitconnect.service.event.ExerciseEventUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,6 +30,8 @@ public class ExerciseEventController {
     private final ExerciseEventRegistrationService registrationService;
 
     private final ExerciseEventFindService exerciseEventFindService;
+
+    private final ExerciseEventUpdateService updateService;
     private final CommonService commonService;
 
     @PostMapping("/register")
@@ -44,5 +50,15 @@ public class ExerciseEventController {
             @RequestParam(required = false) String description) {
         Page<ExerciseEvent> events = exerciseEventFindService.findEvents(category, description, page);
         return ResponseEntity.ok(events);
+    }
+
+    @PutMapping("/{eventId}")
+    public ResponseEntity<ExerciseEvent> updateEvent(
+            @PathVariable Long eventId,
+            @RequestBody ExerciseEventUpdateDto updateDto,
+            HttpSession session) {
+        Long userId = commonService.extractUserIdFromSession(session);
+        ExerciseEvent updatedEvent = updateService.updateEvent(eventId, updateDto, userId);
+        return ResponseEntity.ok(updatedEvent);
     }
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
@@ -66,7 +66,7 @@ public class ExerciseEventController {
     }
 
     @DeleteMapping("/{eventId}")
-    public ResponseEntity<?> deleteEvent(@PathVariable Long eventId, HttpSession session) {
+    public ResponseEntity<ExerciseEvent> deleteEvent(@PathVariable Long eventId, HttpSession session) {
         Long userId = commonService.extractUserIdFromSession(session);
         exerciseEventDeleteService.deleteEvent(eventId, userId);
         return ResponseEntity.ok().build();

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/event/ExerciseEventController.java
@@ -5,12 +5,14 @@ import com.example.fitconnect.domain.event.domain.Category;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.event.dto.ExerciseEventRegistrationDto;
 import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
+import com.example.fitconnect.service.event.ExerciseEventDeleteService;
 import com.example.fitconnect.service.event.ExerciseEventFindService;
 import com.example.fitconnect.service.event.ExerciseEventRegistrationService;
 import com.example.fitconnect.service.event.ExerciseEventUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,10 +30,10 @@ import jakarta.servlet.http.HttpSession;
 public class ExerciseEventController {
 
     private final ExerciseEventRegistrationService registrationService;
-
     private final ExerciseEventFindService exerciseEventFindService;
-
     private final ExerciseEventUpdateService updateService;
+
+    private final ExerciseEventDeleteService exerciseEventDeleteService;
     private final CommonService commonService;
 
     @PostMapping("/register")
@@ -48,7 +50,8 @@ public class ExerciseEventController {
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Category category,
             @RequestParam(required = false) String description) {
-        Page<ExerciseEvent> events = exerciseEventFindService.findEvents(category, description, page);
+        Page<ExerciseEvent> events = exerciseEventFindService.findEvents(category, description,
+                page);
         return ResponseEntity.ok(events);
     }
 
@@ -61,4 +64,12 @@ public class ExerciseEventController {
         ExerciseEvent updatedEvent = updateService.updateEvent(eventId, updateDto, userId);
         return ResponseEntity.ok(updatedEvent);
     }
+
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<?> deleteEvent(@PathVariable Long eventId, HttpSession session) {
+        Long userId = commonService.extractUserIdFromSession(session);
+        exerciseEventDeleteService.deleteEvent(eventId, userId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/registration/RegistrationApprovalController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/registration/RegistrationApprovalController.java
@@ -1,0 +1,35 @@
+package com.example.fitconnect.controller.registration;
+import com.example.fitconnect.config.service.CommonService;
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.service.registration.RegistrationApprovalService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/registrations")
+public class RegistrationApprovalController {
+
+    private final RegistrationApprovalService approvalService;
+
+    private final CommonService commonService;
+    @PostMapping("/{registrationId}/approve")
+    public ResponseEntity<Registration> approveRegistration(@PathVariable Long registrationId,
+            HttpSession session) {
+
+        Long userId = commonService.extractUserIdFromSession(session);
+        approvalService.approveRegistration(registrationId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{registrationId}/deny")
+    public ResponseEntity<Registration> denyRegistration(@PathVariable Long registrationId,
+           HttpSession session) {
+        Long userId = commonService.extractUserIdFromSession(session);
+        approvalService.denyRegistration(registrationId, userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/registration/RegistrationController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/registration/RegistrationController.java
@@ -2,11 +2,14 @@ package com.example.fitconnect.controller.registration;
 
 import com.example.fitconnect.config.service.CommonService;
 import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.service.registration.RegistrationCancellationService;
 import com.example.fitconnect.service.registration.RegistrationCreationService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RegistrationController {
 
     private final RegistrationCreationService registrationService;
+    private final RegistrationCancellationService cancellationService;
     private final CommonService commonService;
 
     @PostMapping
@@ -25,6 +29,13 @@ public class RegistrationController {
         Long userId = commonService.extractUserIdFromSession(session);
         Registration registration = registrationService.createRegistration(userId, eventId);
         return ResponseEntity.status(HttpStatus.CREATED).body(registration);
+    }
+
+    @DeleteMapping("/{registrationId}")
+    public ResponseEntity<?> cancelRegistration(@PathVariable Long registrationId,HttpSession session) {
+        Long userId = commonService.extractUserIdFromSession(session);
+        cancellationService.cancelRegistration(registrationId, userId);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/registration/RegistrationController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/registration/RegistrationController.java
@@ -1,0 +1,31 @@
+package com.example.fitconnect.controller.registration;
+
+import com.example.fitconnect.config.service.CommonService;
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.service.registration.RegistrationCreationService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/registrations")
+@RequiredArgsConstructor
+public class RegistrationController {
+
+    private final RegistrationCreationService registrationService;
+    private final CommonService commonService;
+
+    @PostMapping
+    public ResponseEntity<Registration> createRegistration(@RequestParam Long eventId, HttpSession session) {
+        Long userId = commonService.extractUserIdFromSession(session);
+        Registration registration = registrationService.createRegistration(userId, eventId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(registration);
+    }
+
+
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/registration/RegistrationController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/registration/RegistrationController.java
@@ -32,7 +32,7 @@ public class RegistrationController {
     }
 
     @DeleteMapping("/{registrationId}")
-    public ResponseEntity<?> cancelRegistration(@PathVariable Long registrationId,HttpSession session) {
+    public ResponseEntity<Registration> cancelRegistration(@PathVariable Long registrationId,HttpSession session) {
         Long userId = commonService.extractUserIdFromSession(session);
         cancellationService.cancelRegistration(registrationId, userId);
         return ResponseEntity.ok().build();

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/event/domain/EventDetail.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/event/domain/EventDetail.java
@@ -21,9 +21,6 @@ public class EventDetail {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 
-    @OneToMany(mappedBy = "exerciseEvent", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Registration> registrations = new ArrayList<>();
-
     public EventDetail(String description, LocalDateTime startDate, LocalDateTime endDate) {
         validateDates(startDate, endDate);;
         this.description = description;

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/event/domain/ExerciseEvent.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/event/domain/ExerciseEvent.java
@@ -6,7 +6,9 @@ import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.domain.global.BaseEntity;
 import com.example.fitconnect.domain.registration.Registration;
 import com.example.fitconnect.domain.user.domain.User;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -35,7 +37,8 @@ public class ExerciseEvent extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "exerciseEvent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonBackReference
+    @OneToMany(mappedBy = "exerciseEvent",cascade = CascadeType.REMOVE,orphanRemoval = true)
     private List<Registration> registrations = new ArrayList<>();
 
 

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/event/domain/ExerciseEvent.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/event/domain/ExerciseEvent.java
@@ -1,5 +1,8 @@
 package com.example.fitconnect.domain.event.domain;
 
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.BusinessException;
+import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.domain.global.BaseEntity;
 import com.example.fitconnect.domain.registration.Registration;
 import com.example.fitconnect.domain.user.domain.User;
@@ -62,6 +65,15 @@ public class ExerciseEvent extends BaseEntity {
         this.registrationPolicy = registrationPolicy;
         this.location = location;
         this.category = category;
+    }
+    public void update(ExerciseEventUpdateDto updateDto, Long userId) {
+        if (!this.organizer.getId().equals(userId)) {
+            throw new BusinessException(ErrorMessages.UNAUTHORIZED_USER);
+        }
+        this.eventDetail = updateDto.getEventDetail().toEntity();
+        this.registrationPolicy = updateDto.getRecruitmentPolicy().toEntity();
+        this.location = updateDto.getLocation().toEntity();
+        this.category = updateDto.getCategory();
     }
 
     public ExerciseEvent() {

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/event/dto/ExerciseEventUpdateDto.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/event/dto/ExerciseEventUpdateDto.java
@@ -1,0 +1,24 @@
+package com.example.fitconnect.domain.event.dto;
+
+import com.example.fitconnect.domain.event.domain.Category;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ExerciseEventUpdateDto {
+    private EventDetailDto eventDetail;
+    private RecruitmentPolicyDto recruitmentPolicy;
+    private LocationDto location;
+    private Category category;
+
+    public ExerciseEventUpdateDto(EventDetailDto eventDetail,
+            RecruitmentPolicyDto recruitmentPolicy,
+            LocationDto location, Category category) {
+        this.eventDetail = eventDetail;
+        this.recruitmentPolicy = recruitmentPolicy;
+        this.location = location;
+        this.category = category;
+    }
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/registration/Registration.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/registration/Registration.java
@@ -3,7 +3,10 @@ package com.example.fitconnect.domain.registration;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.global.BaseEntity;
 import com.example.fitconnect.domain.user.domain.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,8 +14,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Entity
+@Getter
 @Table(name = "registrations")
 public class Registration extends BaseEntity {
 
@@ -24,8 +29,29 @@ public class Registration extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "exercise_event_id")
     private ExerciseEvent exerciseEvent;
+
+    @Enumerated(EnumType.STRING)
+    private RegistrationStatus status = RegistrationStatus.APPLIED;
+
+
+    public Registration(User user, ExerciseEvent exerciseEvent) {
+        this.user = user;
+        this.exerciseEvent = exerciseEvent;
+    }
+
+    public Registration() {
+
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        if(!user.getRegistrations().contains(this)) {
+            user.getRegistrations().add(this);
+        }
+    }
 
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/registration/Registration.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/registration/Registration.java
@@ -1,5 +1,7 @@
 package com.example.fitconnect.domain.registration;
 
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.BusinessException;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.global.BaseEntity;
 import com.example.fitconnect.domain.user.domain.User;
@@ -54,4 +56,10 @@ public class Registration extends BaseEntity {
         }
     }
 
+    public void cancel(Long userId) {
+        if(user.getId() != userId){
+            throw new BusinessException(ErrorMessages.UNAUTHORIZED_USER);
+        }
+        this.status = RegistrationStatus.CANCELED;
+    }
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/registration/Registration.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/registration/Registration.java
@@ -17,9 +17,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "registrations")
 public class Registration extends BaseEntity {
 
@@ -57,9 +59,25 @@ public class Registration extends BaseEntity {
     }
 
     public void cancel(Long userId) {
+        checkAuthentication(userId);
+        this.status = RegistrationStatus.CANCELED;
+    }
+
+    public void approve(Long userId) {
+        checkAuthentication(userId);
+        this.status = RegistrationStatus.APPROVED;
+    }
+
+    public void deny(Long userId){
+        checkAuthentication(userId);
+        this.status = RegistrationStatus.REJECTED;
+    }
+
+    private void checkAuthentication(Long userId) {
         if(user.getId() != userId){
             throw new BusinessException(ErrorMessages.UNAUTHORIZED_USER);
         }
-        this.status = RegistrationStatus.CANCELED;
     }
+
+
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/registration/Registration.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/registration/Registration.java
@@ -5,6 +5,8 @@ import com.example.fitconnect.config.exception.BusinessException;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.global.BaseEntity;
 import com.example.fitconnect.domain.user.domain.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -28,12 +30,12 @@ public class Registration extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
+    @JsonManagedReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "exercise_event_id")
     private ExerciseEvent exerciseEvent;

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/registration/RegistrationStatus.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/registration/RegistrationStatus.java
@@ -1,0 +1,18 @@
+package com.example.fitconnect.domain.registration;
+
+public enum RegistrationStatus {
+    APPLIED("신청됨"),
+    APPROVED("승인됨"),
+    REJECTED("거부됨"),
+    CANCELED("취소됨");
+
+    private final String description;
+
+    RegistrationStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/user/domain/User.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/user/domain/User.java
@@ -6,6 +6,7 @@ import com.example.fitconnect.config.exception.BusinessException;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.global.BaseEntity;
 import com.example.fitconnect.domain.registration.Registration;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
@@ -41,6 +42,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "organizer", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ExerciseEvent> organizedEvents = new ArrayList<>();
 
+    @JsonBackReference
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Registration> registrations = new ArrayList<>();
     public User(UserBaseInfo userBaseInfo, Role role) {

--- a/fitConnect/src/main/java/com/example/fitconnect/repository/registration/RegistrationRepository.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/repository/registration/RegistrationRepository.java
@@ -1,0 +1,10 @@
+package com.example.fitconnect.repository.registration;
+
+import com.example.fitconnect.domain.registration.Registration;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RegistrationRepository extends JpaRepository<Registration, Long> {
+
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventDeleteService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventDeleteService.java
@@ -1,0 +1,27 @@
+package com.example.fitconnect.service.event;
+
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.BusinessException;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExerciseEventDeleteService {
+
+    private final ExerciseEventRepository exerciseEventRepository;
+
+    public void deleteEvent(Long eventId, Long userId) {
+        ExerciseEvent event = exerciseEventRepository.findById(eventId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.EVENT_NOT_FOUND));
+
+        if (!event.getOrganizer().getId().equals(userId)) {
+            throw new BusinessException(ErrorMessages.UNAUTHORIZED_USER);
+        }
+
+        exerciseEventRepository.delete(event);
+    }
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventUpdateService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventUpdateService.java
@@ -7,13 +7,14 @@ import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.repository.event.ExerciseEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ExerciseEventUpdateService {
 
     private final ExerciseEventRepository exerciseEventRepository;
-
+    @Transactional
     public ExerciseEvent updateEvent(Long eventId, ExerciseEventUpdateDto updateDto,Long userId) {
         ExerciseEvent event = exerciseEventRepository.findById(eventId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.EVENT_NOT_FOUND));

--- a/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventUpdateService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventUpdateService.java
@@ -1,0 +1,25 @@
+package com.example.fitconnect.service.event;
+
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExerciseEventUpdateService {
+
+    private final ExerciseEventRepository exerciseEventRepository;
+
+    public ExerciseEvent updateEvent(Long eventId, ExerciseEventUpdateDto updateDto,Long userId) {
+        ExerciseEvent event = exerciseEventRepository.findById(eventId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.EVENT_NOT_FOUND));
+
+        event.update(updateDto, userId);
+
+        return event;
+    }
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationApprovalService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationApprovalService.java
@@ -6,6 +6,7 @@ import com.example.fitconnect.domain.registration.Registration;
 import com.example.fitconnect.repository.registration.RegistrationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,13 +14,13 @@ public class RegistrationApprovalService {
 
     private final RegistrationRepository registrationRepository;
 
-
+    @Transactional
     public void approveRegistration(Long registrationId, Long adminId) {
         Registration registration = findRegistration(registrationId);
         registration.approve(adminId);
     }
 
-
+    @Transactional
     public void denyRegistration(Long registrationId, Long adminId) {
         Registration registration = findRegistration(registrationId);
         registration.deny(adminId);

--- a/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationApprovalService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationApprovalService.java
@@ -1,0 +1,34 @@
+package com.example.fitconnect.service.registration;
+
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.repository.registration.RegistrationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationApprovalService {
+
+    private final RegistrationRepository registrationRepository;
+
+
+    public void approveRegistration(Long registrationId, Long adminId) {
+        Registration registration = findRegistration(registrationId);
+        registration.approve(adminId);
+    }
+
+
+    public void denyRegistration(Long registrationId, Long adminId) {
+        Registration registration = findRegistration(registrationId);
+        registration.deny(adminId);
+    }
+
+    private Registration findRegistration(Long registrationId) {
+        return registrationRepository.findById(registrationId)
+                .orElseThrow(
+                        () -> new EntityNotFoundException(ErrorMessages.REGISTRATION_NOT_FOUND));
+    }
+
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationCancellationService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationCancellationService.java
@@ -9,6 +9,7 @@ import com.example.fitconnect.repository.registration.RegistrationRepository;
 import com.example.fitconnect.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +18,7 @@ public class RegistrationCancellationService {
     private final RegistrationRepository registrationRepository;
 
     private final UserRepository userRepository;
-
+    @Transactional
     public void cancelRegistration(Long registrationId, Long userId) {
 
         Registration registration = registrationRepository.findById(registrationId)

--- a/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationCancellationService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationCancellationService.java
@@ -1,0 +1,30 @@
+package com.example.fitconnect.service.registration;
+
+
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.repository.registration.RegistrationRepository;
+import com.example.fitconnect.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationCancellationService {
+
+    private final RegistrationRepository registrationRepository;
+
+    private final UserRepository userRepository;
+
+    public void cancelRegistration(Long registrationId, Long userId) {
+
+        Registration registration = registrationRepository.findById(registrationId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.EVENT_NOT_FOUND));
+
+        registration.cancel(userId);
+
+    }
+}
+

--- a/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationCancellationService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationCancellationService.java
@@ -21,7 +21,7 @@ public class RegistrationCancellationService {
     public void cancelRegistration(Long registrationId, Long userId) {
 
         Registration registration = registrationRepository.findById(registrationId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.EVENT_NOT_FOUND));
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.REGISTRATION_NOT_FOUND));
 
         registration.cancel(userId);
 

--- a/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationCreationService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/registration/RegistrationCreationService.java
@@ -1,0 +1,46 @@
+package com.example.fitconnect.service.registration;
+
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.domain.registration.RegistrationStatus;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+import com.example.fitconnect.repository.registration.RegistrationRepository;
+import com.example.fitconnect.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationCreationService {
+
+    private final RegistrationRepository registrationRepository;
+    private final UserRepository userRepository;
+    private final ExerciseEventRepository exerciseEventRepository;
+
+    @Transactional
+    public Registration createRegistration(Long userId, Long eventId) {
+        User user = findUser(userId);
+        ExerciseEvent event = findEvent(eventId);
+
+        Registration registration = new Registration(user,event);
+
+        return registrationRepository.save(registration);
+    }
+
+    private ExerciseEvent findEvent(Long eventId) {
+        ExerciseEvent event = exerciseEventRepository.findById(eventId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.EVENT_NOT_FOUND));
+        return event;
+    }
+
+    private User findUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.USER_NOT_FOUND));
+        return user;
+    }
+
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/controller/event/ExerciseEventControllerTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/controller/event/ExerciseEventControllerTest.java
@@ -11,6 +11,7 @@ import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.domain.event.dto.LocationDto;
 import com.example.fitconnect.domain.event.dto.RecruitmentPolicyDto;
 import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.service.event.ExerciseEventDeleteService;
 import com.example.fitconnect.service.event.ExerciseEventFindService;
 import com.example.fitconnect.service.event.ExerciseEventRegistrationService;
 import com.example.fitconnect.service.event.ExerciseEventUpdateService;
@@ -36,6 +37,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -58,6 +60,9 @@ public class ExerciseEventControllerTest {
     @MockBean
     private ExerciseEventUpdateService exerciseEventUpdateService;
 
+    @MockBean
+    private ExerciseEventDeleteService exerciseEventDeleteService;
+
     private final Long userId = 1L;
     private final Long eventId = 1L;
 
@@ -65,7 +70,7 @@ public class ExerciseEventControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(
                 new ExerciseEventController(registrationService, exerciseEventFindService,
-                        exerciseEventUpdateService, commonService)).build();
+                        exerciseEventUpdateService,exerciseEventDeleteService, commonService)).build();
         given(commonService.extractUserIdFromSession(any())).willReturn(userId);
     }
 
@@ -96,6 +101,15 @@ public class ExerciseEventControllerTest {
         performPut("/api/events/" + eventId, updateDto)
                 .andExpect(status().isOk());
     }
+    @Test
+    public void deleteEventShouldReturnStatusOk() throws Exception {
+        Long eventId = 1L;
+        setupDeleteService(eventId);
+
+        performDelete("/api/events/" + eventId)
+                .andExpect(status().isOk());
+    }
+
 
     private void setupRegistrationService(ExerciseEventRegistrationDto dto) {
         given(registrationService.registerEvent(eq(userId), eq(dto)))
@@ -115,6 +129,10 @@ public class ExerciseEventControllerTest {
                 .willReturn(new ExerciseEvent());
     }
 
+    private void setupDeleteService(Long eventId) {
+        doNothing().when(exerciseEventDeleteService).deleteEvent(eq(eventId), eq(userId));
+    }
+
     private ResultActions performPost(String url, Object dto) throws Exception {
         return mockMvc.perform(MockMvcRequestBuilders.post(url)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -132,6 +150,10 @@ public class ExerciseEventControllerTest {
         return mockMvc.perform(put(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(asJsonString(dto)));
+    }
+
+    private ResultActions performDelete(String url) throws Exception {
+        return mockMvc.perform(MockMvcRequestBuilders.delete(url));
     }
 
     private String asJsonString(final Object obj) {

--- a/fitConnect/src/test/java/com/example/fitconnect/controller/event/ExerciseEventControllerTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/controller/event/ExerciseEventControllerTest.java
@@ -7,11 +7,13 @@ import com.example.fitconnect.domain.event.domain.City;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.domain.event.dto.EventDetailDto;
 import com.example.fitconnect.domain.event.dto.ExerciseEventRegistrationDto;
+import com.example.fitconnect.domain.event.dto.ExerciseEventUpdateDto;
 import com.example.fitconnect.domain.event.dto.LocationDto;
 import com.example.fitconnect.domain.event.dto.RecruitmentPolicyDto;
 import com.example.fitconnect.domain.user.domain.User;
 import com.example.fitconnect.service.event.ExerciseEventFindService;
 import com.example.fitconnect.service.event.ExerciseEventRegistrationService;
+import com.example.fitconnect.service.event.ExerciseEventUpdateService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.LocalDateTime;
@@ -26,13 +28,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -46,55 +51,87 @@ public class ExerciseEventControllerTest {
     private JwtService jwtService;
     @MockBean
     private ExerciseEventRegistrationService registrationService;
-
     @MockBean
     private CommonService commonService;
-
     @MockBean
     private ExerciseEventFindService exerciseEventFindService;
+    @MockBean
+    private ExerciseEventUpdateService exerciseEventUpdateService;
+
+    private final Long userId = 1L;
+    private final Long eventId = 1L;
 
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(
                 new ExerciseEventController(registrationService, exerciseEventFindService,
-                        commonService)).build();
+                        exerciseEventUpdateService, commonService)).build();
+        given(commonService.extractUserIdFromSession(any())).willReturn(userId);
     }
 
     @Test
-    public void registerEvent_Success() throws Exception {
-        Long userId = 1L;
+    public void registerEventShouldReturnStatusOk() throws Exception {
         ExerciseEventRegistrationDto registrationDto = createEventRegistrationDto();
+        setupRegistrationService(registrationDto);
 
-        given(commonService.extractUserIdFromSession(any())).willReturn(userId);
-        given(registrationService.registerEvent(eq(userId), eq(registrationDto)))
-                .willReturn(registrationDto.toEntity(new User()));
-
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/events/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(asJsonString(registrationDto)))
+        performPost("/api/events/register", registrationDto)
                 .andExpect(status().isOk());
     }
 
     @Test
-    public void findEvent_Success() throws Exception {
-        int page = 0;
-        Category category = Category.SOCCER;
-        String description = "Soccer match";
-        ExerciseEvent event = createEventRegistrationDto().toEntity(new User());
+    public void findEventShouldReturnStatusOk() throws Exception {
+        setupFindService();
 
-        Page<ExerciseEvent> expectedPage = new PageImpl<>(Collections.singletonList(event),
-                PageRequest.of(page, 10), 1);
-
-        given(exerciseEventFindService.findEvents(category, description, page))
-                .willReturn(expectedPage);
-
-        mockMvc.perform(get("/api/events")
-                        .param("page", "0")
-                        .param("category", "SOCCER")
-                        .param("description", "Soccer match"))
+        performGet("/api/events", "0", "SOCCER", "Soccer match")
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").exists())
                 .andExpect(jsonPath("$.content[0].category").value("SOCCER"));
+    }
+
+    @Test
+    public void updateEventShouldReturnStatusOk() throws Exception {
+        ExerciseEventUpdateDto updateDto = createUpdateDto();
+        setupUpdateService(updateDto);
+
+        performPut("/api/events/" + eventId, updateDto)
+                .andExpect(status().isOk());
+    }
+
+    private void setupRegistrationService(ExerciseEventRegistrationDto dto) {
+        given(registrationService.registerEvent(eq(userId), eq(dto)))
+                .willReturn(dto.toEntity(new User()));
+    }
+
+    private void setupFindService() {
+        ExerciseEvent event = createEventRegistrationDto().toEntity(new User());
+        Page<ExerciseEvent> expectedPage = new PageImpl<>(Collections.singletonList(event),
+                PageRequest.of(0, 10), 1);
+        given(exerciseEventFindService.findEvents(any(), any(), anyInt()))
+                .willReturn(expectedPage);
+    }
+
+    private void setupUpdateService(ExerciseEventUpdateDto dto) {
+        given(exerciseEventUpdateService.updateEvent(eq(eventId), eq(dto), eq(userId)))
+                .willReturn(new ExerciseEvent());
+    }
+
+    private ResultActions performPost(String url, Object dto) throws Exception {
+        return mockMvc.perform(MockMvcRequestBuilders.post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(dto)));
+    }
+
+    private ResultActions performGet(String url, String page, String category, String description) throws Exception {
+        return mockMvc.perform(get(url)
+                .param("page", page)
+                .param("category", category)
+                .param("description", description));
+    }
+
+    private ResultActions performPut(String url, Object dto) throws Exception {
+        return mockMvc.perform(put(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(dto)));
     }
 
     private String asJsonString(final Object obj) {
@@ -117,5 +154,14 @@ public class ExerciseEventControllerTest {
 
         return new ExerciseEventRegistrationDto(eventDetailDto,
                 recruitmentPolicyDto, locationDto, category);
+    }
+
+    private ExerciseEventUpdateDto createUpdateDto() {
+        return new ExerciseEventUpdateDto(
+                new EventDetailDto("Updated Description", LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(1).plusHours(2)),
+                new RecruitmentPolicyDto(50, LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2)),
+                new LocationDto(City.SEOUL, "서울시 송파구"),
+                Category.BASKETBALL
+        );
     }
 }

--- a/fitConnect/src/test/java/com/example/fitconnect/controller/registration/RegistrationApprovalControllerTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/controller/registration/RegistrationApprovalControllerTest.java
@@ -1,0 +1,62 @@
+package com.example.fitconnect.controller.registration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.fitconnect.auth.service.JwtService;
+import com.example.fitconnect.config.service.CommonService;
+import com.example.fitconnect.service.registration.RegistrationApprovalService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(RegistrationApprovalController.class)
+class RegistrationApprovalControllerTest {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RegistrationApprovalService approvalService;
+
+    @MockBean
+    private CommonService commonService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(
+                new RegistrationApprovalController(approvalService, commonService)).build();
+    }
+
+    @Test
+    void approveRegistration_Success() throws Exception {
+        Long registrationId = 1L;
+        Long adminId = 2L;
+
+        mockMvc.perform(post("/api/registrations/" + registrationId + "/approve")
+                        .param("adminId", adminId.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void denyRegistration_Success() throws Exception {
+        Long registrationId = 1L;
+        Long adminId = 2L;
+
+        mockMvc.perform(post("/api/registrations/" + registrationId + "/deny")
+                        .param("adminId", adminId.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/controller/registration/RegistrationControllerTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/controller/registration/RegistrationControllerTest.java
@@ -1,0 +1,57 @@
+package com.example.fitconnect.controller.registration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.fitconnect.auth.service.JwtService;
+import com.example.fitconnect.config.service.CommonService;
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.service.registration.RegistrationCreationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+
+@WebMvcTest(RegistrationController.class)
+class RegistrationControllerTest {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RegistrationCreationService registrationService;
+    @MockBean
+    private CommonService commonService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(
+                new RegistrationController(registrationService, commonService)).build();
+    }
+
+    @Test
+    void createRegistration_Success() throws Exception {
+        Long userId = 1L;
+        Long eventId = 1L;
+        Registration registration = new Registration();
+
+        given(commonService.extractUserIdFromSession(any())).willReturn(userId);
+        given(registrationService.createRegistration(userId, eventId)).willReturn(registration);
+
+        mockMvc.perform(post("/api/registrations")
+                        .param("eventId", eventId.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/domain/registration/RegistrationTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/domain/registration/RegistrationTest.java
@@ -1,0 +1,24 @@
+package com.example.fitconnect.domain.registration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.domain.user.domain.User;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RegistrationCreationTest {
+
+    @Test
+    void createRegistration() {
+        User user = new User();
+        ExerciseEvent exerciseEvent = new ExerciseEvent();
+
+        Registration registration = new Registration(user, exerciseEvent);
+
+        assertThat(registration.getUser()).isEqualTo(user);
+        assertThat(registration.getExerciseEvent()).isEqualTo(exerciseEvent);
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/service/event/ExerciseEventDeleteServiceTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/service/event/ExerciseEventDeleteServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.fitconnect.service.event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.example.fitconnect.config.exception.BusinessException;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.domain.user.domain.Role;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.domain.user.domain.UserBaseInfo;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ExerciseEventDeleteServiceTest {
+
+    @Mock
+    private ExerciseEventRepository exerciseEventRepository;
+
+    @InjectMocks
+    private ExerciseEventDeleteService exerciseEventDeleteService;
+
+    private User user;
+    private ExerciseEvent event;
+    private Long eventId = 1L;
+    private Long userId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(new UserBaseInfo("user@example.com", "nickname", "url"), Role.MEMBER);
+        user.setId(userId);
+        event = new ExerciseEvent();
+        event.setOrganizer(user);
+    }
+
+    @Test
+    void deleteEvent_Success() {
+        given(exerciseEventRepository.findById(eventId)).willReturn(Optional.of(event));
+
+        exerciseEventDeleteService.deleteEvent(eventId, userId);
+
+    }
+
+    @Test
+    void deleteEvent_NotFoundEntity() {
+        given(exerciseEventRepository.findById(eventId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> exerciseEventDeleteService.deleteEvent(eventId, userId))
+                .isInstanceOf(EntityNotFoundException.class);
+
+    }
+
+    @Test
+    void deleteEvent_InvalidUser() {
+        Long anotherUserId = 2L;
+        given(exerciseEventRepository.findById(eventId)).willReturn(Optional.of(event));
+
+        assertThatThrownBy(() -> exerciseEventDeleteService.deleteEvent(eventId, anotherUserId))
+                .isInstanceOf(BusinessException.class);
+
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/service/event/ExerciseEventUpdateServiceTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/service/event/ExerciseEventUpdateServiceTest.java
@@ -1,0 +1,84 @@
+package com.example.fitconnect.service.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.*;
+import com.example.fitconnect.domain.event.dto.*;
+import com.example.fitconnect.domain.user.domain.Role;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.domain.user.domain.UserBaseInfo;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+
+import com.example.fitconnect.service.event.ExerciseEventUpdateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+class ExerciseEventUpdateServiceTest {
+
+    @Mock
+    private ExerciseEventRepository repository;
+
+    @InjectMocks
+    private ExerciseEventUpdateService service;
+
+    private User user;
+    private ExerciseEvent existingEvent;
+    private ExerciseEventUpdateDto updateDto;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(new UserBaseInfo("test123@naver.com", "hi", ".com"), Role.MEMBER);
+        user.setId(1L);
+        existingEvent = createEvent();
+        updateDto = createUpdateDto();
+    }
+
+    @Test
+    void updateValidEvent() {
+        given(repository.findById(1L)).willReturn(Optional.of(existingEvent));
+
+        ExerciseEvent updatedEvent = service.updateEvent(1L, updateDto, 1L);
+
+        assertThat(updatedEvent).isNotNull();
+        assertThat(updatedEvent.getEventDetail().getDescription())
+                .isEqualTo(updateDto.getEventDetail().getDescription());
+        assertThat(updatedEvent.getCategory()).isEqualTo(updateDto.getCategory());
+    }
+
+    @Test
+    void updateInvalidEvent() {
+        given(repository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateEvent(1L, updateDto, 1L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    private ExerciseEvent createEvent() {
+        return new ExerciseEventRegistrationDto(
+                new EventDetailDto("Description", LocalDateTime.now(), LocalDateTime.now().plusHours(2)),
+                new RecruitmentPolicyDto(30, LocalDateTime.now(), LocalDateTime.now().plusDays(1)),
+                new LocationDto(City.SEOUL, "서울시 강남구"),
+                Category.SOCCER
+        ).toEntity(user);
+    }
+
+    private ExerciseEventUpdateDto createUpdateDto() {
+        return new ExerciseEventUpdateDto(
+                new EventDetailDto("Updated Description", LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(1).plusHours(2)),
+                new RecruitmentPolicyDto(50, LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2)),
+                new LocationDto(City.SEOUL, "서울시 송파구"),
+                Category.BASKETBALL
+        );
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/service/registration/RegistrationApprovalServiceTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/service/registration/RegistrationApprovalServiceTest.java
@@ -1,0 +1,77 @@
+package com.example.fitconnect.service.registration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.domain.registration.RegistrationStatus;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.repository.registration.RegistrationRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class RegistrationApprovalServiceTest {
+
+    @Mock
+    private RegistrationRepository registrationRepository;
+
+    @InjectMocks
+    private RegistrationApprovalService service;
+
+    private Registration registration;
+    private Long registrationId = 1L;
+    private Long userId = 2L;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        registration = new Registration();
+        User user = new User();
+        user.setId(userId);
+        registration.setUser(user);
+    }
+
+    @Test
+    public void approve_Success() {
+        registration.setStatus(RegistrationStatus.APPROVED);
+        when(registrationRepository.findById(registrationId)).thenReturn(Optional.of(registration));
+
+        service.approveRegistration(registrationId, userId);
+
+        assertThat(registration.getStatus()).isEqualTo(RegistrationStatus.APPROVED);
+    }
+
+    @Test
+    public void approve_NotFound() {
+        when(registrationRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.approveRegistration(registrationId, userId))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    public void deny_Success() {
+        registration.setStatus(RegistrationStatus.REJECTED);
+        when(registrationRepository.findById(registrationId)).thenReturn(Optional.of(registration));
+
+
+        service.denyRegistration(registrationId, userId);
+
+        assertThat(registration.getStatus()).isEqualTo(RegistrationStatus.REJECTED);
+    }
+
+    @Test
+    public void deny_NotFound() {
+        when(registrationRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.denyRegistration(registrationId, userId))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/service/registration/RegistrationCancellationServiceTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/service/registration/RegistrationCancellationServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.fitconnect.service.registration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.fitconnect.config.error.ErrorMessages;
+import com.example.fitconnect.config.exception.BusinessException;
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.registration.Registration;
+import com.example.fitconnect.domain.registration.RegistrationStatus;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.repository.registration.RegistrationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationCancellationServiceTest {
+
+    @Mock
+    private RegistrationRepository registrationRepository;
+
+    @InjectMocks
+    private RegistrationCancellationService registrationCancellationService;
+
+    private User user;
+    private Registration registration;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+        registration = new Registration(user, null);
+    }
+
+    @Test
+    void CancellationUpdates_Success() {
+        given(registrationRepository.findById(registration.getId())).willReturn(Optional.of(registration));
+
+        registrationCancellationService.cancelRegistration(registration.getId(), user.getId());
+
+        assertThat(registration.getStatus()).isEqualTo(RegistrationStatus.CANCELED);
+        verify(registrationRepository).findById(registration.getId());
+    }
+
+    @Test
+    void notFoundRegistration_Test() {
+        Long wrongId = 2L;
+        given(registrationRepository.findById(wrongId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> registrationCancellationService.cancelRegistration(wrongId, user.getId()))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void unauthorizedUserThrowsException_Test() {
+        Long differentUserId = 2L;
+        given(registrationRepository.findById(registration.getId())).willReturn(Optional.of(registration));
+
+        assertThatThrownBy(() -> registrationCancellationService.cancelRegistration(registration.getId(), differentUserId))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/fitConnect/src/test/java/com/example/fitconnect/service/registration/RegistrationCreationServiceTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/service/registration/RegistrationCreationServiceTest.java
@@ -1,0 +1,75 @@
+package com.example.fitconnect.service.registration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.domain.ExerciseEvent;
+import com.example.fitconnect.domain.user.domain.User;
+import com.example.fitconnect.repository.event.ExerciseEventRepository;
+import com.example.fitconnect.repository.registration.RegistrationRepository;
+import com.example.fitconnect.repository.user.UserRepository;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationServiceTest {
+
+    @Mock
+    private RegistrationRepository registrationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ExerciseEventRepository exerciseEventRepository;
+
+    @InjectMocks
+    private RegistrationCreationService registrationService;
+
+    private User testUser;
+    private ExerciseEvent testEvent;
+    private Long validUserId = 1L;
+    private Long validEventId = 1L;
+    private Long invalidUserId = 99L;
+    private Long invalidEventId = 99L;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testEvent = new ExerciseEvent();
+    }
+
+    @Test
+    void createRegistration_Success() {
+        given(userRepository.findById(validUserId)).willReturn(Optional.of(testUser));
+        given(exerciseEventRepository.findById(validEventId)).willReturn(Optional.of(testEvent));
+
+        assertThatCode(() -> registrationService.createRegistration(validUserId, validEventId))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void createRegistration_UserNotFound() {
+        given(userRepository.findById(invalidUserId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> registrationService.createRegistration(invalidUserId, validEventId))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void createRegistration_EventNotFound() {
+        given(userRepository.findById(validUserId)).willReturn(Optional.of(testUser));
+        given(exerciseEventRepository.findById(invalidEventId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(
+                () -> registrationService.createRegistration(validUserId, invalidEventId))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## 1. Changes

- 운동 이벤트 신청 생성,취소,승인,거부 로직을 구현했습니다. 
- 
- 



## 3. Issues

1 취소, 승인,거부 로직을 실제로 테스트 했을때 값을 바뀌는데 Db에 적용이 되지 않아 왜그랬는데 했는데 @Transactional 을 통해 해결했습니다. 
2. 

## 4. To Reviewer

-

## 5. Plans
- [ ] - 리뷰 작성,수정,삭제.조회
- [ ] - 리뷰 도메인 생성
