### PR TITLE
Fix/websocket session handling

### DIFF
--- a/fitConnect/build.gradle
+++ b/fitConnect/build.gradle
@@ -35,10 +35,12 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     testImplementation 'org.springframework.security:spring-security-test'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client', version: '2.5.4'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.16.0'
     implementation 'com.google.api-client:google-api-client:2.2.0'
+
     implementation 'com.google.http-client:google-http-client-jackson2:1.43.1'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/fitConnect/frontend/package.json
+++ b/fitConnect/frontend/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^6.21.3",
     "react-scripts": "5.0.1",
     "sockjs-client": "^1.6.1",
+    "stompjs": "^2.3.3",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/fitConnect/frontend/src/App.js
+++ b/fitConnect/frontend/src/App.js
@@ -6,6 +6,8 @@ import PostListPage from './page/PostListPage';
 import {AuthProvider} from "./global/AuthContext";
 import EventCreatePage from "./page/EventCreatePage";
 import EventDetailPage from "./page/EventDetailPage";
+import CreateChatRoom from "./components/CreateChatRoom";
+import ChatRoomListPage from "./page/ChatRoomListPage";
 function App() {
   return (
       <AuthProvider>
@@ -17,6 +19,7 @@ function App() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/event" element={<PostListPage />} />
             <Route path="/events/:eventId" element={<EventDetailPage />} />
+            <Route path="/chatRooms" element={<ChatRoomListPage/>} />
           </Routes>
         </Router>
       </GoogleOAuthProvider>

--- a/fitConnect/frontend/src/components/ChatModal.js
+++ b/fitConnect/frontend/src/components/ChatModal.js
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react';
+import { Modal, Button, Form, ListGroup } from 'react-bootstrap';
+import SockJS from 'sockjs-client';
+import { Stomp } from '@stomp/stompjs';
+
+const ChatModal = ({ show, onHide, chatRoomId }) => {
+  const [message, setMessage] = useState('');
+  const [messages, setMessages] = useState([]);
+  const [stompClient, setStompClient] = useState(null);
+
+  useEffect(() => {
+    if (show) {
+      const socket = new SockJS('http://localhost:8080/ws');
+      const client = Stomp.over(socket);
+      client.connect({}, () => {
+        console.log("Connected: " + chatRoomId);
+        console.log(stompClient)
+        stompClient.subscribe(`/topic/chatrooms/${chatRoomId}`, (message) => {
+          const newMessage = JSON.parse(message.body);
+          setMessages((prevMessages) => [...prevMessages, newMessage]);
+        });
+      });
+      setStompClient(client);
+
+      return () => {
+        if (stompClient !== null) {
+          stompClient.disconnect();
+          console.log("Disconnected");
+        }
+      };
+    }
+  }, [show, chatRoomId]);
+
+  const handleSendMessage = () => {
+    if (message && stompClient) {
+      stompClient.send(`/app/chat/${chatRoomId}/sendMessage`, {}, JSON.stringify(message));
+      setMessage('');
+    }else{
+      console.log(message , stompClient)
+    }
+  };
+
+  return (
+      <Modal show={show} onHide={onHide}>
+        <Modal.Header closeButton>
+          <Modal.Title>채팅</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <ListGroup>
+            {messages.map((msg, index) => (
+                <ListGroup.Item key={index}>{msg.content}</ListGroup.Item>
+            ))}
+          </ListGroup>
+          <Form>
+            <Form.Group className="mb-3">
+              <Form.Control
+                  type="text"
+                  placeholder="메시지 입력..."
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+              />
+            </Form.Group>
+            <Button variant="primary" onClick={handleSendMessage}>
+              전송
+            </Button>
+          </Form>
+        </Modal.Body>
+      </Modal>
+  );
+};
+
+export default ChatModal;

--- a/fitConnect/frontend/src/components/CreateChatRoom.js
+++ b/fitConnect/frontend/src/components/CreateChatRoom.js
@@ -23,6 +23,7 @@ const CreateChatRoom = ({ eventId }) => {
       setTitle('');
       handleClose();
       alert('채팅방이 성공적으로 생성되었습니다!');
+      window.location.href = '/chatRooms'
     } catch (error) {
       setError('채팅방 생성에 실패했습니다. 다시 시도해주세요.');
     }

--- a/fitConnect/frontend/src/page/ChatRoomListPage.js
+++ b/fitConnect/frontend/src/page/ChatRoomListPage.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+import { Card, ListGroup, Container, Row, Col, Badge } from 'react-bootstrap';
+import Navbar from "../components/Navbar";
+
+const ChatRoomPage = () => {
+  const { chatRoomId } = useParams();
+  const [chatRoom, setChatRoom] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchMessages = async () => {
+      try {
+        const params = {
+          page: 0,
+          size: 10,
+        };
+        const response = await axios.get(`/api/chatrooms/messages`, { params });
+        setChatRoom(response.data);
+        console.log(response.data);
+      } catch (error) {
+        setError('메시지를 불러오는데 실패했습니다.');
+      }
+    };
+
+    fetchMessages();
+  }, [chatRoomId]);
+
+  return (
+      <>
+        <Navbar/>
+        <Container className="mt-4">
+          <Row className="justify-content-center">
+            <Col lg={8}>
+              {error && <p className="text-danger">{error}</p>}
+              <Card className="shadow-sm">
+                <Card.Header as="h5">
+                  채팅방 메시지 <Badge bg="secondary">New</Badge>
+                </Card.Header>
+                <ListGroup variant="flush">
+                  {chatRoom && chatRoom.content.length > 0 ? (
+                      chatRoom.content.map((message) => (
+                          <ListGroup.Item key={message.id}>
+                            <h6>{message.title}</h6>
+                            <p className="mb-1">{message.content}</p>
+                            <small>업데이트: {new Date(message.updatedAt).toLocaleString()}</small>
+                          </ListGroup.Item>
+                      ))
+                  ) : (
+                      <ListGroup.Item>채팅 메시지가 없습니다.</ListGroup.Item>
+                  )}
+                </ListGroup>
+              </Card>
+            </Col>
+          </Row>
+        </Container>
+      </>
+  );
+};
+
+export default ChatRoomPage;

--- a/fitConnect/frontend/src/page/ChatRoomListPage.js
+++ b/fitConnect/frontend/src/page/ChatRoomListPage.js
@@ -1,57 +1,90 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
-import { Card, ListGroup, Container, Row, Col, Badge } from 'react-bootstrap';
+import {
+  Card,
+  ListGroup,
+  Container,
+  Row,
+  Col,
+  Button,
+  Pagination
+} from 'react-bootstrap';
 import Navbar from "../components/Navbar";
+import ChatModal from "../components/ChatModal";
 
 const ChatRoomPage = () => {
-  const { chatRoomId } = useParams();
-  const [chatRoom, setChatRoom] = useState(null);
+  const [chatRooms, setChatRooms] = useState([]); // 채팅방 목록을 저장할 상태
+  const [currentPage, setCurrentPage] = useState(0); // 현재 페이지
+  const [totalPages, setTotalPages] = useState(0); // 전체 페이지 수
   const [error, setError] = useState('');
+  const [modalShow, setModalShow] = useState(null); // 현재 열려있는 모달의 ID
 
   useEffect(() => {
-    const fetchMessages = async () => {
-      try {
-        const params = {
-          page: 0,
-          size: 10,
-        };
-        const response = await axios.get(`/api/chatrooms/messages`, { params });
-        setChatRoom(response.data);
-        console.log(response.data);
-      } catch (error) {
-        setError('메시지를 불러오는데 실패했습니다.');
-      }
-    };
+    fetchChatRooms(currentPage);
+  }, [currentPage]);
 
-    fetchMessages();
-  }, [chatRoomId]);
+  const fetchChatRooms = async (page) => {
+    try {
+      const params = {
+        page,
+        size: 10,
+      };
+      const response = await axios.get(`/api/chatrooms/messages`, { params }); // API 엔드포인트 확인 필요
+      setChatRooms(response.data.content);
+      setTotalPages(response.data.totalPages);
+    } catch (error) {
+      setError('채팅방을 불러오는데 실패했습니다.');
+      console.error(error);
+    }
+  };
+
+  const handlePageChange = (pageNumber) => {
+    setCurrentPage(pageNumber);
+  };
 
   return (
       <>
-        <Navbar/>
+        <Navbar />
         <Container className="mt-4">
           <Row className="justify-content-center">
             <Col lg={8}>
               {error && <p className="text-danger">{error}</p>}
               <Card className="shadow-sm">
-                <Card.Header as="h5">
-                  채팅방 메시지 <Badge bg="secondary">New</Badge>
-                </Card.Header>
+                <Card.Header as="h5">채팅방 목록</Card.Header>
                 <ListGroup variant="flush">
-                  {chatRoom && chatRoom.content.length > 0 ? (
-                      chatRoom.content.map((message) => (
-                          <ListGroup.Item key={message.id}>
-                            <h6>{message.title}</h6>
-                            <p className="mb-1">{message.content}</p>
-                            <small>업데이트: {new Date(message.updatedAt).toLocaleString()}</small>
-                          </ListGroup.Item>
-                      ))
-                  ) : (
-                      <ListGroup.Item>채팅 메시지가 없습니다.</ListGroup.Item>
-                  )}
+                  {chatRooms.map((chatRoom) => (
+                      <ListGroup.Item key={chatRoom.id}>
+                        <div className="d-flex justify-content-between align-items-center">
+                          <div>
+                            <h6>{chatRoom.title}</h6>
+                            <small>
+                              마지막 업데이트: {new Date(chatRoom.updatedAt).toLocaleString()}
+                            </small>
+                            <p>{chatRoom.messages.length > 0 ? chatRoom.messages[chatRoom.messages.length - 1].content : "메시지 없음"}</p>
+                          </div>
+                          <Button variant="primary" onClick={() => setModalShow(chatRoom.id)}>
+                            채팅하기
+                          </Button>
+                        </div>
+                        {modalShow === chatRoom.id && (
+                            <ChatModal
+                                show={modalShow === chatRoom.id}
+                                onHide={() => setModalShow(null)}
+                                chatRoomId={chatRoom.id}
+                            />
+                        )}
+                      </ListGroup.Item>
+                  ))}
                 </ListGroup>
               </Card>
+              <Pagination className="justify-content-center">
+                {[...Array(totalPages).keys()].map((page) => (
+                    <Pagination.Item key={page} active={page === currentPage} onClick={() => handlePageChange(page)}>
+                      {page + 1}
+                    </Pagination.Item>
+                ))}
+              </Pagination>
             </Col>
           </Row>
         </Container>

--- a/fitConnect/src/main/java/com/example/fitconnect/auth/filter/JwtFilter.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/auth/filter/JwtFilter.java
@@ -48,7 +48,8 @@ public class JwtFilter extends OncePerRequestFilter {
         HttpSession session = request.getSession();
         String accessToken = getTokenFromSession(session, "accessToken");
         String refreshToken = getTokenFromSession(session, "refreshToken");
-
+        log.info("엑세스 토큰  :  {}", accessToken);
+        log.info("리프레시 토큰 : {}",refreshToken);
         if (accessToken != null && jwtService.validateAccessToken(accessToken)) {
             setAuthenticationContext(jwtService.getUserIdByParseToken(accessToken));
         } else if (refreshToken != null) {
@@ -69,7 +70,7 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private boolean isPermitAllPath(String requestURI) {
-        return requestURI.startsWith("/ws") || requestURI.startsWith("/api/auth/google")
+        return  requestURI.startsWith("/api/auth/google")
                 || requestURI.startsWith("/swagger-ui")
                 || requestURI.startsWith("/v3/api-docs") || requestURI.startsWith("/h2-console");
     }

--- a/fitConnect/src/main/java/com/example/fitconnect/config/interceptor/CustomHandshakeInterceptor.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/config/interceptor/CustomHandshakeInterceptor.java
@@ -1,0 +1,24 @@
+package com.example.fitconnect.config.interceptor;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+
+@Slf4j
+public class CustomHandshakeInterceptor extends HttpSessionHandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+            WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+        attributes.put("userId",userId);
+        log.info("userId = {} ",userId);
+        return super.beforeHandshake(request, response, wsHandler, attributes);
+    }
+}

--- a/fitConnect/src/main/java/com/example/fitconnect/config/webSocket/WebSocketConfig.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/config/webSocket/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.example.fitconnect.config.webSocket;
 
+import com.example.fitconnect.config.interceptor.CustomHandshakeInterceptor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -15,7 +16,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/{chatRoomId}").setAllowedOrigins("http://localhost:3000")
-                .withSockJS();
+                .withSockJS()
+                .setInterceptors(new CustomHandshakeInterceptor());;
     }
 
     @Override

--- a/fitConnect/src/main/java/com/example/fitconnect/controller/chat/ChatController.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/controller/chat/ChatController.java
@@ -10,8 +10,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Controller
 @RequiredArgsConstructor
@@ -22,11 +25,10 @@ public class ChatController {
 
     @MessageMapping("/chat/{chatRoomId}/sendMessage")
     @SendTo("/topic/{chatRoomId}")
-    public ResponseEntity<ChatMessage> sendMessage(@DestinationVariable String chatRoomId,
-            ChatMessageRegistrationDto chatMessageRegistrationDto, @CurrentUserId Long userId) {
-        log.info("Received message in chat room {}: {}", chatRoomId, chatMessageRegistrationDto);
+    public ResponseEntity<ChatMessage> sendMessage(SimpMessageHeaderAccessor headerAccessor,String message,@DestinationVariable Long chatRoomId) {
+        Long userId = (Long) headerAccessor.getSessionAttributes().get("userId");
         ChatMessage chatMessage = chatMessageCreationService.createChatMessage(
-                chatMessageRegistrationDto, userId);
+                message,chatRoomId ,userId);
         return ResponseEntity.ok().body(chatMessage);
     }
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/domain/chat/dto/ChatMessageRegistrationDto.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/domain/chat/dto/ChatMessageRegistrationDto.java
@@ -1,14 +1,16 @@
 package com.example.fitconnect.domain.chat.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
 public class ChatMessageRegistrationDto {
-    private Long chatRoomId;
+
     private String content;
 
-    public ChatMessageRegistrationDto(Long chatRoomId, String content) {
-        this.chatRoomId = chatRoomId;
-        this.content = content;
-    }
 }

--- a/fitConnect/src/main/java/com/example/fitconnect/service/chat/chatMessage/ChatMessageCreationService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/chat/chatMessage/ChatMessageCreationService.java
@@ -25,11 +25,11 @@ public class ChatMessageCreationService {
     private final UserFindService userFindService;
 
     @Transactional
-    public ChatMessage createChatMessage(ChatMessageRegistrationDto dto,Long userId) {
-        ChatRoom chatRoom = findChatRoom(dto);
+    public ChatMessage createChatMessage(String message,Long chatRoomId,Long userId) {
+        ChatRoom chatRoom = findChatRoom(message,chatRoomId);
         User sender = findUser(userId);
 
-        ChatMessage chatMessage = new ChatMessage(dto.getContent(), chatRoom, sender);
+        ChatMessage chatMessage = new ChatMessage(message, chatRoom, sender);
         return chatMessageRepository.save(chatMessage);
     }
 
@@ -39,8 +39,8 @@ public class ChatMessageCreationService {
         return sender;
     }
 
-    private ChatRoom findChatRoom(ChatMessageRegistrationDto dto) {
-        ChatRoom chatRoom = chatRoomFindService.findChatRoomByChatRoomId(dto.getChatRoomId())
+    private ChatRoom findChatRoom(String message,Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomFindService.findChatRoomByChatRoomId(chatRoomId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.CHATROOM_NOT_FOUND));
         return chatRoom;
     }

--- a/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventRegistrationService.java
+++ b/fitConnect/src/main/java/com/example/fitconnect/service/event/ExerciseEventRegistrationService.java
@@ -2,17 +2,21 @@ package com.example.fitconnect.service.event;
 
 import com.example.fitconnect.config.error.ErrorMessages;
 import com.example.fitconnect.config.exception.EntityNotFoundException;
+import com.example.fitconnect.domain.event.dto.EventDetailDto;
 import com.example.fitconnect.domain.event.dto.ExerciseEventRegistrationDto;
+import com.example.fitconnect.domain.event.dto.RecruitmentPolicyDto;
 import com.example.fitconnect.domain.user.domain.User;
 import com.example.fitconnect.domain.event.domain.ExerciseEvent;
 import com.example.fitconnect.repository.event.ExerciseEventRepository;
 import com.example.fitconnect.service.user.UserFindService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ExerciseEventRegistrationService {
 
     private final ExerciseEventRepository exerciseEventRepository;

--- a/fitConnect/src/test/java/com/example/fitconnect/controller/chat/ChatRoomControllerTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/controller/chat/ChatRoomControllerTest.java
@@ -131,7 +131,7 @@ public class ChatRoomControllerTest {
         given(chatRoomFindService.getChatMessages( userId, pageable)).willReturn(
                 mockPage);
 
-        mockMvc.perform(get("/api/chatrooms/" + chatRoomId + "/messages")
+        mockMvc.perform(get("/api/chatrooms/messages")
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk());

--- a/fitConnect/src/test/java/com/example/fitconnect/service/chat/chatMessage/ChatMessageCreationServiceTest.java
+++ b/fitConnect/src/test/java/com/example/fitconnect/service/chat/chatMessage/ChatMessageCreationServiceTest.java
@@ -40,17 +40,17 @@ public class ChatMessageCreationServiceTest {
     public void testCreateChatMessageSuccess() {
         // 준비
         Long userId = 1L;
-        ChatMessageRegistrationDto dto = new ChatMessageRegistrationDto(1L, "테스트 메시지");
+        ChatMessageRegistrationDto dto = new ChatMessageRegistrationDto( "테스트 메시지");
         User mockUser = new User();
         ChatRoom mockChatRoom = new ChatRoom();
         ChatMessage mockChatMessage = new ChatMessage("테스트 메시지", mockChatRoom, mockUser);
 
         when(userFindService.findUserByUserId(userId)).thenReturn(Optional.of(mockUser));
-        when(chatRoomFindService.findChatRoomByChatRoomId(dto.getChatRoomId())).thenReturn(
+        when(chatRoomFindService.findChatRoomByChatRoomId(any(Long.class))).thenReturn(
                 Optional.of(mockChatRoom));
         when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(mockChatMessage);
 
-        ChatMessage createdChatMessage = chatMessageCreationService.createChatMessage(dto, userId);
+        ChatMessage createdChatMessage = chatMessageCreationService.createChatMessage("message",1L, userId);
 
         assertThat(createdChatMessage).isNotNull()
                 .extracting("content", "chatRoom", "sender")
@@ -59,23 +59,23 @@ public class ChatMessageCreationServiceTest {
     @Test
     public void testCreateChatMessageFail_UserNotFound() {
         Long userId = 1L;
-        ChatMessageRegistrationDto dto = new ChatMessageRegistrationDto(1L, "테스트 메시지");
+        ChatMessageRegistrationDto dto = new ChatMessageRegistrationDto( "테스트 메시지");
 
         when(userFindService.findUserByUserId(userId)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> chatMessageCreationService.createChatMessage(dto, userId))
+        assertThatThrownBy(() -> chatMessageCreationService.createChatMessage("message",1L, userId))
                 .isInstanceOf(EntityNotFoundException.class);
     }
     @Test
     public void testCreateChatMessageFail_ChatRoomNotFound() {
         Long userId = 1L;
-        ChatMessageRegistrationDto dto = new ChatMessageRegistrationDto(1L, "테스트 메시지");
+        ChatMessageRegistrationDto dto = new ChatMessageRegistrationDto( "테스트 메시지");
         User mockUser = new User();
 
         when(userFindService.findUserByUserId(userId)).thenReturn(Optional.of(mockUser));
-        when(chatRoomFindService.findChatRoomByChatRoomId(dto.getChatRoomId())).thenReturn(Optional.empty());
+        when(chatRoomFindService.findChatRoomByChatRoomId(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> chatMessageCreationService.createChatMessage(dto, userId))
+        assertThatThrownBy(() -> chatMessageCreationService.createChatMessage("message",1L, userId))
                 .isInstanceOf(EntityNotFoundException.class);
     }
 


### PR DESCRIPTION
## 1. Changes
front
- 채팅방 리스트 호출 기능추가
- 메세지 전송기능 추가

back
- CustomHandshakeInterceptor 구현 하여 SecurityCotext의 유저정보 WebSocket Session에 저장


## 3. Issues
채팅을 위한 WebSocket을 연결하고 메세지를 전달 시키는 과정에서 직렬화 문제가 계속 발생했습니다 이유가 뭘까하고 Dto값을 변경하는등 여러가지 방법을 사용했는데요. 알고보니 WebSocket프로토콜은 Http 프로토콜과 달라  HTTP 세션 또는 SecurityContext와 같은 상태를 자동으로 공유하지 않아서 생기는 문제였습니다. SecurityContext에 유저정보를 저장해두던 방식을 
CustomHandshakeInterceptor을 통해 WebSocket Session에 SecurityContext에 유저정보를 저장하는 방식으로 문제를 해결했습니다.
## 4. To Reviewer

-

## 5. Plans
- [ ] - 기존 메세지 호출 기능
- [ ] - 채팅메세지 삭제 기능 추가  